### PR TITLE
Switching to the recommended link checking config, for #6

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,5 +1,5 @@
 {
-  "timeout": "20s",
+  "timeout": "60s",
   "retryOn429": true,
   "retryCount": 5,
   "fallbackRetryDelay": "30s",

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,6 +1,7 @@
 {
-  "aliveStatusCodes": [429, 200],
-  "timeout": "30s",
-  "retryCount": 3,
-  "fallbackRetryDelay": "30s"
+  "timeout": "20s",
+  "retryOn429": true,
+  "retryCount": 5,
+  "fallbackRetryDelay": "30s",
+  "aliveStatusCodes": [200, 206]
 }


### PR DESCRIPTION
This change uses the recommended link checker config, waiting and re-trying if there's a 429.