### PR TITLE
Add Wayback-Archive to Save Digital Stuff Right Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Spotted digital data at risk, but don't know who can save it?
     - [webcitation.org](http://webcitation.org/)
     - [UK Web Archive Site Nomination](https://www.webarchive.org.uk/ukwa/info/nominate) - Suggest URLs for the UK Web Archive. _Note that UKWA is offline at present._ <!-- markdown-link-check-disable-line -->
 - Alert the [Archive Team](http://archiveteam.org/), and [help them save digital stuff](http://archiveteam.org/index.php?title=Who_We_Are)
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. _(Python, GPL-3.0)_
 
 ### Learn About Digital Preservation
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Spotted digital data at risk, but don't know who can save it?
     - [webcitation.org](http://webcitation.org/)
     - [UK Web Archive Site Nomination](https://www.webarchive.org.uk/ukwa/info/nominate) - Suggest URLs for the UK Web Archive. _Note that UKWA is offline at present._ <!-- markdown-link-check-disable-line -->
 - Alert the [Archive Team](http://archiveteam.org/), and [help them save digital stuff](http://archiveteam.org/index.php?title=Who_We_Are)
-- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. _(Python, GPL-3.0)_
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing by [GeiserX](https://github.com/GeiserX).
 
 ### Learn About Digital Preservation
 


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Save Digital Stuff Right Now** section.
- Wayback-Archive is a Python (GPL-3.0) tool that downloads complete websites from the Wayback Machine with full asset preservation for offline viewing.
- It rewrites internal links and preserves all assets (HTML, CSS, JS, images, fonts, etc.) so archived sites can be browsed offline exactly as they appeared.

## Why it's awesome

The Wayback Machine is an invaluable digital preservation resource, but accessing archived content typically requires an internet connection and navigating the Wayback Machine's interface. Wayback-Archive bridges this gap by enabling users to download and preserve complete website snapshots locally, ensuring continued access even if the Wayback Machine itself becomes unavailable.