### PR TITLE
Add PastPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Spotted digital data at risk, but don't know who can save it?
     - [perma.cc](https://perma.cc/)
     - [webcitation.org](http://webcitation.org/)
     - [UK Web Archive Site Nomination](https://www.webarchive.org.uk/ukwa/info/nominate) - Suggest URLs for the UK Web Archive. _Note that UKWA is offline at present._ <!-- markdown-link-check-disable-line -->
+    - [PastPage](https://github.com/nabertronic/pastpage) - Browser extension for recovering broken or changed pages from the Wayback Machine and other web archives by [nabertronic](https://github.com/nabertronic).
 - Alert the [Archive Team](http://archiveteam.org/), and [help them save digital stuff](http://archiveteam.org/index.php?title=Who_We_Are)
 
 ### Learn About Digital Preservation

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Spotted digital data at risk, but don't know who can save it?
     - [perma.cc](https://perma.cc/)
     - [webcitation.org](http://webcitation.org/)
     - [UK Web Archive Site Nomination](https://www.webarchive.org.uk/ukwa/info/nominate) - Suggest URLs for the UK Web Archive. _Note that UKWA is offline at present._ <!-- markdown-link-check-disable-line -->
+- Recover broken or changed web pages via:
     - [PastPage](https://github.com/nabertronic/pastpage) - Browser extension for recovering broken or changed pages from the Wayback Machine and other web archives by [nabertronic](https://github.com/nabertronic).
 - Alert the [Archive Team](http://archiveteam.org/), and [help them save digital stuff](http://archiveteam.org/index.php?title=Who_We_Are)
 


### PR DESCRIPTION
Adds PastPage to the Save Digital Stuff Right Now section as a recovery helper for broken or changed web pages. PastPage is a browser extension that helps people locate preserved copies by querying the Wayback Machine and other web archives in parallel.\n\nDisclosure: I maintain PastPage.